### PR TITLE
inline bach dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
-    "arr-flatten": "^1.0.1",
     "arr-map": "^2.0.0",
     "array-each": "^1.0.0",
     "array-initial": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
-    "array-each": "^1.0.0",
     "array-initial": "^1.0.0",
     "array-last": "^1.1.1",
     "async-done": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,22 @@
     "test": "mocha --async-only **/test/*.mjs"
   },
   "dependencies": {
-    "bach": "^1.0.0",
     "collection-map": "^1.0.0",
     "fast-levenshtein": "^1.0.0",
     "glob-watcher": "^5.0.3",
     "gulp-cli": "^2.2.0",
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
-    "vinyl-fs": "^3.0.0"
+    "vinyl-fs": "^3.0.0",
+    "arr-filter": "^1.1.1",
+    "arr-flatten": "^1.0.1",
+    "arr-map": "^2.0.0",
+    "array-each": "^1.0.0",
+    "array-initial": "^1.0.0",
+    "array-last": "^1.1.1",
+    "async-done": "^1.2.2",
+    "async-settle": "^1.0.0",
+    "now-and-later": "^2.0.0"
   },
   "devDependencies": {
     "expect": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
     "array-initial": "^1.0.0",
-    "array-last": "^1.1.1",
     "async-done": "^1.2.2",
     "async-settle": "^1.0.0",
     "now-and-later": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
-    "arr-map": "^2.0.0",
     "array-each": "^1.0.0",
     "array-initial": "^1.0.0",
     "array-last": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
-    "array-initial": "^1.0.0",
     "async-done": "^1.2.2",
     "async-settle": "^1.0.0",
     "now-and-later": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "last-run": "^1.1.0",
     "undertaker-registry": "^1.0.0",
     "vinyl-fs": "^3.0.0",
-    "arr-filter": "^1.1.1",
     "arr-flatten": "^1.0.1",
     "arr-map": "^2.0.0",
     "array-each": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,30 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  bach:
+  arr-filter:
+    specifier: ^1.1.1
+    version: 1.1.2
+  arr-flatten:
+    specifier: ^1.0.1
+    version: 1.1.0
+  arr-map:
+    specifier: ^2.0.0
+    version: 2.0.2
+  array-each:
     specifier: ^1.0.0
-    version: 1.2.0
+    version: 1.0.1
+  array-initial:
+    specifier: ^1.0.0
+    version: 1.1.0
+  array-last:
+    specifier: ^1.1.1
+    version: 1.3.0
+  async-done:
+    specifier: ^1.2.2
+    version: 1.3.2
+  async-settle:
+    specifier: ^1.0.0
+    version: 1.0.0
   collection-map:
     specifier: ^1.0.0
     version: 1.0.0
@@ -23,6 +44,9 @@ dependencies:
   last-run:
     specifier: ^1.1.0
     version: 1.1.1
+  now-and-later:
+    specifier: ^2.0.0
+    version: 2.0.1
   undertaker-registry:
     specifier: ^1.0.0
     version: 1.0.1
@@ -306,21 +330,6 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
-
-  /bach@1.2.0:
-    resolution: {integrity: sha512-bZOOfCb3gXBXbTFXq3OZtGR88LwGeJvzu6szttaIzymOTS4ZttBNOWSv7aLZja2EMycKtRYV0Oa8SNKH/zkxvg==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      arr-filter: 1.1.2
-      arr-flatten: 1.1.0
-      arr-map: 2.0.2
-      array-each: 1.0.1
-      array-initial: 1.1.0
-      array-last: 1.3.0
-      async-done: 1.3.2
-      async-settle: 1.0.0
-      now-and-later: 2.0.1
-    dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  arr-flatten:
-    specifier: ^1.0.1
-    version: 1.1.0
   arr-map:
     specifier: ^2.0.0
     version: 2.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   array-initial:
     specifier: ^1.0.0
     version: 1.1.0
-  array-last:
-    specifier: ^1.1.1
-    version: 1.3.0
   async-done:
     specifier: ^1.2.2
     version: 1.3.2
@@ -216,13 +213,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       array-slice: 1.1.0
-      is-number: 4.0.0
-    dev: false
-
-  /array-last@1.3.0:
-    resolution: {integrity: sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
       is-number: 4.0.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  array-initial:
-    specifier: ^1.0.0
-    version: 1.1.0
   async-done:
     specifier: ^1.2.2
     version: 1.3.2
@@ -206,14 +203,6 @@ packages:
   /array-each@1.0.1:
     resolution: {integrity: sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /array-initial@1.1.0:
-    resolution: {integrity: sha512-BC4Yl89vneCYfpLrs5JU2aAu9/a+xWbeKhvISg9PT7eWFB9UlRvI+rKEtk6mgxWr3dSkk9gQ8hCrdqt06NXPdw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-slice: 1.1.0
-      is-number: 4.0.0
     dev: false
 
   /array-slice@1.1.0:
@@ -1832,11 +1821,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       kind-of: 3.2.2
-    dev: false
-
-  /is-number@4.0.0:
-    resolution: {integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /is-number@7.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  array-each:
-    specifier: ^1.0.0
-    version: 1.0.1
   array-initial:
     specifier: ^1.0.0
     version: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  arr-map:
-    specifier: ^2.0.0
-    version: 2.0.2
   array-each:
     specifier: ^1.0.0
     version: 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  arr-filter:
-    specifier: ^1.1.1
-    version: 1.1.2
   arr-flatten:
     specifier: ^1.0.1
     version: 1.1.0
@@ -187,13 +184,6 @@ packages:
   /arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /arr-filter@1.1.2:
-    resolution: {integrity: sha512-A2BETWCqhsecSvCkWAeVBFLH6sXEUGASuzkpjL3GR1SlL/PWL6M3J8EAAld2Uubmh39tvkJTqC9LeLHCUKmFXA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      make-iterator: 1.0.1
     dev: false
 
   /arr-flatten@1.1.0:

--- a/src/bach/index.js
+++ b/src/bach/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  series: require('./lib/series'),
+  parallel: require('./lib/parallel'),
+  settleSeries: require('./lib/settleSeries'),
+  settleParallel: require('./lib/settleParallel'),
+};

--- a/src/bach/index.js
+++ b/src/bach/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
   series: require('./lib/series'),
   parallel: require('./lib/parallel'),

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var assert = require('assert');
+
+var filter = require('arr-filter');
+var map = require('arr-map');
+var flatten = require('arr-flatten');
+var forEach = require('array-each');
+
+function noop() {}
+
+function getExtensions(lastArg) {
+  if (typeof lastArg !== 'function') {
+    return lastArg;
+  }
+}
+
+function filterSuccess(elem) {
+  return elem.state === 'success';
+}
+
+function filterError(elem) {
+  return elem.state === 'error';
+}
+
+function buildOnSettled(done) {
+  if (typeof done !== 'function') {
+    done = noop;
+  }
+
+  function onSettled(error, result) {
+    if (error) {
+      return done(error, null);
+    }
+
+    var settledErrors = filter(result, filterError);
+    var settledResults = filter(result, filterSuccess);
+
+    var errors = null;
+    if (settledErrors.length) {
+      errors = map(settledErrors, 'value');
+    }
+
+    var results = null;
+    if (settledResults.length) {
+      results = map(settledResults, 'value');
+    }
+
+    done(errors, results);
+  }
+
+  return onSettled;
+}
+
+function verifyArguments(args) {
+  args = flatten(args);
+  var lastIdx = args.length - 1;
+
+  assert.ok(args.length, 'A set of functions to combine is required');
+
+  forEach(args, function(arg, argIdx) {
+    var isFunction = typeof arg === 'function';
+    if (isFunction) {
+      return;
+    }
+
+    if (argIdx === lastIdx) {
+      // Last arg can be an object of extension points
+      return;
+    }
+
+    var msg = 'Only functions can be combined, got ' + typeof arg +
+      ' for argument ' + argIdx;
+    assert.ok(isFunction, msg);
+  });
+
+  return args;
+}
+
+module.exports = {
+  getExtensions: getExtensions,
+  onSettled: buildOnSettled,
+  verifyArguments: verifyArguments,
+};

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 
 const map = require('arr-map');
-const flatten = require('arr-flatten');
 const forEach = require('array-each');
 
 function noop() {}
@@ -50,7 +49,7 @@ function buildOnSettled(done) {
 }
 
 function verifyArguments(args) {
-  args = flatten(args);
+  args = [...args].flat(Infinity);
   const lastIdx = args.length - 1;
 
   assert.ok(args.length, 'A set of functions to combine is required');

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 
-const filter = require('arr-filter');
 const map = require('arr-map');
 const flatten = require('arr-flatten');
 const forEach = require('array-each');
@@ -31,8 +30,8 @@ function buildOnSettled(done) {
       return done(error, null);
     }
 
-    const settledErrors = filter(result, filterError);
-    const settledResults = filter(result, filterSuccess);
+    const settledErrors = result.filter(filterError);
+    const settledResults = result.filter(filterSuccess);
 
     let errors = null;
     if (settledErrors.length) {

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 
-const map = require('arr-map');
 const forEach = require('array-each');
 
 function noop() {}
@@ -32,17 +31,11 @@ function buildOnSettled(done) {
     const settledErrors = result.filter(filterError);
     const settledResults = result.filter(filterSuccess);
 
-    let errors = null;
-    if (settledErrors.length) {
-      errors = map(settledErrors, 'value');
-    }
 
-    let results = null;
-    if (settledResults.length) {
-      results = map(settledResults, 'value');
-    }
+    const errors = settledErrors.map(e => e.value);
+    const results = settledResults.map(r => r.value);
 
-    done(errors, results);
+    done(errors.length ? errors : null, results.length ? results : null);
   }
 
   return onSettled;

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,11 +1,9 @@
-'use strict';
+const assert = require('assert');
 
-var assert = require('assert');
-
-var filter = require('arr-filter');
-var map = require('arr-map');
-var flatten = require('arr-flatten');
-var forEach = require('array-each');
+const filter = require('arr-filter');
+const map = require('arr-map');
+const flatten = require('arr-flatten');
+const forEach = require('array-each');
 
 function noop() {}
 
@@ -33,15 +31,15 @@ function buildOnSettled(done) {
       return done(error, null);
     }
 
-    var settledErrors = filter(result, filterError);
-    var settledResults = filter(result, filterSuccess);
+    const settledErrors = filter(result, filterError);
+    const settledResults = filter(result, filterSuccess);
 
-    var errors = null;
+    let errors = null;
     if (settledErrors.length) {
       errors = map(settledErrors, 'value');
     }
 
-    var results = null;
+    let results = null;
     if (settledResults.length) {
       results = map(settledResults, 'value');
     }
@@ -54,12 +52,12 @@ function buildOnSettled(done) {
 
 function verifyArguments(args) {
   args = flatten(args);
-  var lastIdx = args.length - 1;
+  const lastIdx = args.length - 1;
 
   assert.ok(args.length, 'A set of functions to combine is required');
 
   forEach(args, function(arg, argIdx) {
-    var isFunction = typeof arg === 'function';
+    const isFunction = typeof arg === 'function';
     if (isFunction) {
       return;
     }
@@ -69,7 +67,7 @@ function verifyArguments(args) {
       return;
     }
 
-    var msg = 'Only functions can be combined, got ' + typeof arg +
+    const msg = 'Only functions can be combined, got ' + typeof arg +
       ' for argument ' + argIdx;
     assert.ok(isFunction, msg);
   });

--- a/src/bach/lib/helpers.js
+++ b/src/bach/lib/helpers.js
@@ -1,7 +1,5 @@
 const assert = require('assert');
 
-const forEach = require('array-each');
-
 function noop() {}
 
 function getExtensions(lastArg) {
@@ -47,21 +45,22 @@ function verifyArguments(args) {
 
   assert.ok(args.length, 'A set of functions to combine is required');
 
-  forEach(args, function(arg, argIdx) {
+  for(let argIdx = 0; argIdx < args.length; argIdx++) {
+    const arg = args[argIdx];
     const isFunction = typeof arg === 'function';
     if (isFunction) {
-      return;
+      continue;
     }
 
     if (argIdx === lastIdx) {
       // Last arg can be an object of extension points
-      return;
+      continue;
     }
 
     const msg = 'Only functions can be combined, got ' + typeof arg +
       ' for argument ' + argIdx;
     assert.ok(isFunction, msg);
-  });
+  }
 
   return args;
 }

--- a/src/bach/lib/parallel.js
+++ b/src/bach/lib/parallel.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var initial = require('array-initial');
+var last = require('array-last');
+var asyncDone = require('async-done');
+var nowAndLater = require('now-and-later');
+
+var helpers = require('./helpers');
+
+function iterator(fn, key, cb) {
+  return asyncDone(fn, cb);
+}
+
+function buildParallel() {
+  var args = helpers.verifyArguments(arguments);
+
+  var extensions = helpers.getExtensions(last(args));
+
+  if (extensions) {
+    args = initial(args);
+  }
+
+  function parallel(done) {
+    nowAndLater.map(args, iterator, extensions, done);
+  }
+
+  return parallel;
+}
+
+module.exports = buildParallel;

--- a/src/bach/lib/parallel.js
+++ b/src/bach/lib/parallel.js
@@ -1,4 +1,3 @@
-const initial = require('array-initial');
 const asyncDone = require('async-done');
 const nowAndLater = require('now-and-later');
 
@@ -14,7 +13,7 @@ function buildParallel() {
   const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
-    args = initial(args);
+    args = args.slice(0, args.length - 1);
   }
 
   function parallel(done) {

--- a/src/bach/lib/parallel.js
+++ b/src/bach/lib/parallel.js
@@ -1,5 +1,4 @@
 const initial = require('array-initial');
-const last = require('array-last');
 const asyncDone = require('async-done');
 const nowAndLater = require('now-and-later');
 
@@ -11,8 +10,8 @@ function iterator(fn, key, cb) {
 
 function buildParallel() {
   let args = helpers.verifyArguments(arguments);
-
-  const extensions = helpers.getExtensions(last(args));
+  const lastEl = args.length === 0 ? null : args[args.length - 1];
+  const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/parallel.js
+++ b/src/bach/lib/parallel.js
@@ -1,20 +1,18 @@
-'use strict';
+const initial = require('array-initial');
+const last = require('array-last');
+const asyncDone = require('async-done');
+const nowAndLater = require('now-and-later');
 
-var initial = require('array-initial');
-var last = require('array-last');
-var asyncDone = require('async-done');
-var nowAndLater = require('now-and-later');
-
-var helpers = require('./helpers');
+const helpers = require('./helpers');
 
 function iterator(fn, key, cb) {
   return asyncDone(fn, cb);
 }
 
 function buildParallel() {
-  var args = helpers.verifyArguments(arguments);
+  let args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(last(args));
+  const extensions = helpers.getExtensions(last(args));
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/series.js
+++ b/src/bach/lib/series.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var initial = require('array-initial');
+var last = require('array-last');
+var asyncDone = require('async-done');
+var nowAndLater = require('now-and-later');
+
+var helpers = require('./helpers');
+
+function iterator(fn, key, cb) {
+  return asyncDone(fn, cb);
+}
+
+function buildSeries() {
+  var args = helpers.verifyArguments(arguments);
+
+  var extensions = helpers.getExtensions(last(args));
+
+  if (extensions) {
+    args = initial(args);
+  }
+
+  function series(done) {
+    nowAndLater.mapSeries(args, iterator, extensions, done);
+  }
+
+  return series;
+}
+
+module.exports = buildSeries;

--- a/src/bach/lib/series.js
+++ b/src/bach/lib/series.js
@@ -1,4 +1,3 @@
-const initial = require('array-initial');
 const asyncDone = require('async-done');
 const nowAndLater = require('now-and-later');
 
@@ -14,7 +13,7 @@ function buildSeries() {
   const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
-    args = initial(args);
+    args = args.slice(0, args.length - 1);
   }
 
   function series(done) {

--- a/src/bach/lib/series.js
+++ b/src/bach/lib/series.js
@@ -1,20 +1,18 @@
-'use strict';
+const initial = require('array-initial');
+const last = require('array-last');
+const asyncDone = require('async-done');
+const nowAndLater = require('now-and-later');
 
-var initial = require('array-initial');
-var last = require('array-last');
-var asyncDone = require('async-done');
-var nowAndLater = require('now-and-later');
-
-var helpers = require('./helpers');
+const helpers = require('./helpers');
 
 function iterator(fn, key, cb) {
   return asyncDone(fn, cb);
 }
 
 function buildSeries() {
-  var args = helpers.verifyArguments(arguments);
+  let args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(last(args));
+  const extensions = helpers.getExtensions(last(args));
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/series.js
+++ b/src/bach/lib/series.js
@@ -1,5 +1,4 @@
 const initial = require('array-initial');
-const last = require('array-last');
 const asyncDone = require('async-done');
 const nowAndLater = require('now-and-later');
 
@@ -11,8 +10,8 @@ function iterator(fn, key, cb) {
 
 function buildSeries() {
   let args = helpers.verifyArguments(arguments);
-
-  const extensions = helpers.getExtensions(last(args));
+  const lastEl = args.length === 0 ? null : args[args.length - 1];
+  const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/settleParallel.js
+++ b/src/bach/lib/settleParallel.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var initial = require('array-initial');
+var last = require('array-last');
+var asyncSettle = require('async-settle');
+var nowAndLater = require('now-and-later');
+
+var helpers = require('./helpers');
+
+function iterator(fn, key, cb) {
+  return asyncSettle(fn, cb);
+}
+
+function buildSettleParallel() {
+  var args = helpers.verifyArguments(arguments);
+
+  var extensions = helpers.getExtensions(last(args));
+
+  if (extensions) {
+    args = initial(args);
+  }
+
+  function settleParallel(done) {
+    var onSettled = helpers.onSettled(done);
+    nowAndLater.map(args, iterator, extensions, onSettled);
+  }
+
+  return settleParallel;
+}
+
+module.exports = buildSettleParallel;

--- a/src/bach/lib/settleParallel.js
+++ b/src/bach/lib/settleParallel.js
@@ -1,5 +1,4 @@
 const initial = require('array-initial');
-const last = require('array-last');
 const asyncSettle = require('async-settle');
 const nowAndLater = require('now-and-later');
 
@@ -11,8 +10,8 @@ function iterator(fn, key, cb) {
 
 function buildSettleParallel() {
   let args = helpers.verifyArguments(arguments);
-
-  const extensions = helpers.getExtensions(last(args));
+  const lastEl = args.length === 0 ? null : args[args.length - 1];
+  const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/settleParallel.js
+++ b/src/bach/lib/settleParallel.js
@@ -1,27 +1,25 @@
-'use strict';
+const initial = require('array-initial');
+const last = require('array-last');
+const asyncSettle = require('async-settle');
+const nowAndLater = require('now-and-later');
 
-var initial = require('array-initial');
-var last = require('array-last');
-var asyncSettle = require('async-settle');
-var nowAndLater = require('now-and-later');
-
-var helpers = require('./helpers');
+const helpers = require('./helpers');
 
 function iterator(fn, key, cb) {
   return asyncSettle(fn, cb);
 }
 
 function buildSettleParallel() {
-  var args = helpers.verifyArguments(arguments);
+  let args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(last(args));
+  const extensions = helpers.getExtensions(last(args));
 
   if (extensions) {
     args = initial(args);
   }
 
   function settleParallel(done) {
-    var onSettled = helpers.onSettled(done);
+    const onSettled = helpers.onSettled(done);
     nowAndLater.map(args, iterator, extensions, onSettled);
   }
 

--- a/src/bach/lib/settleParallel.js
+++ b/src/bach/lib/settleParallel.js
@@ -1,4 +1,3 @@
-const initial = require('array-initial');
 const asyncSettle = require('async-settle');
 const nowAndLater = require('now-and-later');
 
@@ -14,7 +13,7 @@ function buildSettleParallel() {
   const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
-    args = initial(args);
+    args = args.slice(0, args.length - 1);
   }
 
   function settleParallel(done) {

--- a/src/bach/lib/settleSeries.js
+++ b/src/bach/lib/settleSeries.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var initial = require('array-initial');
+var last = require('array-last');
+var asyncSettle = require('async-settle');
+var nowAndLater = require('now-and-later');
+
+var helpers = require('./helpers');
+
+function iterator(fn, key, cb) {
+  return asyncSettle(fn, cb);
+}
+
+function buildSettleSeries() {
+  var args = helpers.verifyArguments(arguments);
+
+  var extensions = helpers.getExtensions(last(args));
+
+  if (extensions) {
+    args = initial(args);
+  }
+
+  function settleSeries(done) {
+    var onSettled = helpers.onSettled(done);
+    nowAndLater.mapSeries(args, iterator, extensions, onSettled);
+  }
+
+  return settleSeries;
+}
+
+module.exports = buildSettleSeries;

--- a/src/bach/lib/settleSeries.js
+++ b/src/bach/lib/settleSeries.js
@@ -1,27 +1,25 @@
-'use strict';
+const initial = require('array-initial');
+const last = require('array-last');
+const asyncSettle = require('async-settle');
+const nowAndLater = require('now-and-later');
 
-var initial = require('array-initial');
-var last = require('array-last');
-var asyncSettle = require('async-settle');
-var nowAndLater = require('now-and-later');
-
-var helpers = require('./helpers');
+const helpers = require('./helpers');
 
 function iterator(fn, key, cb) {
   return asyncSettle(fn, cb);
 }
 
 function buildSettleSeries() {
-  var args = helpers.verifyArguments(arguments);
+  let args = helpers.verifyArguments(arguments);
 
-  var extensions = helpers.getExtensions(last(args));
+  const extensions = helpers.getExtensions(last(args));
 
   if (extensions) {
     args = initial(args);
   }
 
   function settleSeries(done) {
-    var onSettled = helpers.onSettled(done);
+    const onSettled = helpers.onSettled(done);
     nowAndLater.mapSeries(args, iterator, extensions, onSettled);
   }
 

--- a/src/bach/lib/settleSeries.js
+++ b/src/bach/lib/settleSeries.js
@@ -1,5 +1,4 @@
 const initial = require('array-initial');
-const last = require('array-last');
 const asyncSettle = require('async-settle');
 const nowAndLater = require('now-and-later');
 
@@ -11,8 +10,8 @@ function iterator(fn, key, cb) {
 
 function buildSettleSeries() {
   let args = helpers.verifyArguments(arguments);
-
-  const extensions = helpers.getExtensions(last(args));
+  const lastEl = args.length === 0 ? null : args[args.length - 1];
+  const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
     args = initial(args);

--- a/src/bach/lib/settleSeries.js
+++ b/src/bach/lib/settleSeries.js
@@ -1,4 +1,3 @@
-const initial = require('array-initial');
 const asyncSettle = require('async-settle');
 const nowAndLater = require('now-and-later');
 
@@ -14,7 +13,7 @@ function buildSettleSeries() {
   const extensions = helpers.getExtensions(lastEl);
 
   if (extensions) {
-    args = initial(args);
+    args = args.slice(0, args.length - 1);
   }
 
   function settleSeries(done) {

--- a/src/bach/test/getExtensions.mjs
+++ b/src/bach/test/getExtensions.mjs
@@ -1,0 +1,18 @@
+const {default: expect} = await import('expect');
+
+const {getExtensions} = await import('../lib/helpers.js');
+
+describe('getExtensions', function() {
+  it('should return the argument if it is an object', function(done) {
+    const obj = {};
+    expect(getExtensions(obj)).toEqual(obj);
+    done();
+  });
+
+  it('should return undefined if argument is not an object', function(done) {
+    const fn = function () {
+    };
+    expect(getExtensions(fn)).toEqual(undefined);
+    done();
+  });
+});

--- a/src/bach/test/onSettled.mjs
+++ b/src/bach/test/onSettled.mjs
@@ -1,0 +1,37 @@
+const {default: expect} = await import('expect');
+
+const {onSettled} = await import('../lib/helpers.js');
+
+const errors = [
+  {state: 'error', value: new Error('Error 1')},
+  {state: 'error', value: new Error('Error 2')},
+];
+
+describe('onSettled', function() {
+
+  it('should group all errors', function(done) {
+    onSettled(function(errs, results) {
+      expect(errs.length).toEqual(2);
+      expect(results).toEqual(null);
+      done();
+    })(null, errors);
+  });
+
+  it('should error early if called with an error', function(done) {
+    onSettled(function(err, results) {
+      expect(err).toBeAn(Error);
+      expect(results).toEqual(null);
+      done();
+    })(new Error('Should not happen'));
+  });
+
+  it('should handle the no callback case', function(done) {
+    onSettled()(null, errors);
+    done();
+  });
+
+  it('should handle non-functions as callbacks', function(done) {
+    onSettled('not a function')(null, errors);
+    done();
+  });
+});

--- a/src/bach/test/parallel.mjs
+++ b/src/bach/test/parallel.mjs
@@ -1,0 +1,68 @@
+const {default: expect} = await import('expect');
+
+const {default: bach} = await import('../index.js');
+
+function fn1(done) {
+  done(null, 1);
+}
+
+function fn2(done) {
+  setTimeout(function() {
+    done(null, 2);
+  }, 500);
+}
+
+function fn3(done) {
+  done(null, 3);
+}
+
+function fnError(done) {
+  done(new Error('An Error Occurred'));
+}
+
+describe('parallel', function() {
+
+  it('should execute functions in parallel, passing results', function(done) {
+    bach.parallel(fn1, fn2, fn3)(function(error, results) {
+      expect(error).toEqual(null);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should execute functions in parallel, passing error', function(done) {
+    function slowFn(done) {
+      setTimeout(function() {
+        expect('slow function should not be called').toEqual(undefined);
+        done(null, 2);
+      }, 500);
+    }
+    bach.parallel(fn1, slowFn, fn3, fnError)(function(error, results) {
+      expect(error).toBeAn(Error);
+      expect(results).toEqual([1, undefined, 3, undefined]);
+      done();
+    });
+  });
+
+  it('should take extension points and call them for each function', function(done) {
+    const arr = [];
+    const fns = [fn1, fn2, fn3];
+    bach.parallel(fn1, fn2, fn3, {
+      create: function(fn, idx) {
+        expect(fns).toInclude(fn);
+        arr[idx] = fn;
+        return arr;
+      },
+      before: function(storage) {
+        expect(storage).toEqual(arr);
+      },
+      after: function(result, storage) {
+        expect(storage).toEqual(arr);
+      },
+    })(function(error) {
+      expect(error).toEqual(null);
+      expect(arr).toEqual(fns);
+    });
+    done();
+  });
+});

--- a/src/bach/test/series.mjs
+++ b/src/bach/test/series.mjs
@@ -1,0 +1,67 @@
+const {default: expect} = await import('expect');
+
+const {default: bach} = await import('../index.js');
+
+function fn1(done) {
+  done(null, 1);
+}
+
+function fn2(done) {
+  setTimeout(function() {
+    done(null, 2);
+  }, 500);
+}
+
+function fn3(done) {
+  done(null, 3);
+}
+
+function fnError(done) {
+  done(new Error('An Error Occurred'));
+}
+
+describe('series', function() {
+
+  it('should execute functions in series, passing results', function(done) {
+    bach.series(fn1, fn2, fn3)(function(error, results) {
+      expect(error).toEqual(null);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should execute functions in series, passing error', function(done) {
+    function slowFn(done) {
+      setTimeout(function() {
+        done(null, 2);
+      }, 500);
+    }
+    bach.series(fn1, slowFn, fn3, fnError)(function(error, results) {
+      expect(error).toBeAn(Error);
+      expect(results).toEqual([1, 2, 3, undefined]);
+      done();
+    });
+  });
+
+  it('should take extension points and call them for each function', function(done) {
+    const arr = [];
+    const fns = [fn1, fn2, fn3];
+    bach.series(fn1, fn2, fn3, {
+      create: function(fn, idx) {
+        expect(fns).toInclude(fn);
+        arr[idx] = fn;
+        return arr;
+      },
+      before: function(storage) {
+        expect(storage).toEqual(arr);
+      },
+      after: function(result, storage) {
+        expect(storage).toEqual(arr);
+      },
+    })(function(error) {
+      expect(error).toEqual(null);
+      expect(arr).toEqual(fns);
+    });
+    done();
+  });
+});

--- a/src/bach/test/settleParallel.mjs
+++ b/src/bach/test/settleParallel.mjs
@@ -1,0 +1,68 @@
+const {default: expect} = await import('expect');
+
+const {default: bach} = await import('../index.js');
+
+function fn1(done) {
+  done(null, 1);
+}
+
+function fn2(done) {
+  setTimeout(function() {
+    done(null, 2);
+  }, 500);
+}
+
+function fn3(done) {
+  done(null, 3);
+}
+
+function fnError(done) {
+  done(new Error('An Error Occurred'));
+}
+
+describe('settleParallel', function() {
+
+  it('should execute functions in parallel, passing settled results', function(done) {
+    bach.settleParallel(fn1, fn2, fn3)(function(errors, results) {
+      expect(errors).toEqual(null);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should execute functions in parallel, passing settled errors and results', function(done) {
+    function slowFn(done) {
+      setTimeout(function() {
+        done(null, 2);
+      }, 500);
+    }
+    bach.settleParallel(fn1, slowFn, fn3, fnError)(function(errors, results) {
+      expect(errors).toBeAn(Array);
+      expect(errors[0]).toBeAn(Error);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should take extension points and call them for each function', function(done) {
+    const arr = [];
+    const fns = [fn1, fn2, fn3];
+    bach.settleParallel(fn1, fn2, fn3, {
+      create: function(fn, idx) {
+        expect(fns).toInclude(fn);
+        arr[idx] = fn;
+        return arr;
+      },
+      before: function(storage) {
+        expect(storage).toEqual(arr);
+      },
+      after: function(result, storage) {
+        expect(storage).toEqual(arr);
+      },
+    })(function(error) {
+      expect(error).toEqual(null);
+      expect(arr).toEqual(fns);
+    });
+    done();
+  });
+});

--- a/src/bach/test/settleSeries.mjs
+++ b/src/bach/test/settleSeries.mjs
@@ -1,0 +1,68 @@
+const {default: expect} = await import('expect');
+
+const {default: bach} = await import('../index.js');
+
+function fn1(done) {
+  done(null, 1);
+}
+
+function fn2(done) {
+  setTimeout(function() {
+    done(null, 2);
+  }, 500);
+}
+
+function fn3(done) {
+  done(null, 3);
+}
+
+function fnError(done) {
+  done(new Error('An Error Occurred'));
+}
+
+describe('settleSeries', function() {
+
+  it('should execute functions in series, passing settled results', function(done) {
+    bach.settleSeries(fn1, fn2, fn3)(function(errors, results) {
+      expect(errors).toEqual(null);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should execute functions in series, passing settled errors and results', function(done) {
+    function slowFn(done) {
+      setTimeout(function() {
+        done(null, 2);
+      }, 500);
+    }
+    bach.settleSeries(fn1, slowFn, fn3, fnError)(function(errors, results) {
+      expect(errors).toBeAn(Array);
+      expect(errors[0]).toBeAn(Error);
+      expect(results).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should take extension points and call them for each function', function(done) {
+    const arr = [];
+    const fns = [fn1, fn2, fn3];
+    bach.settleSeries(fn1, fn2, fn3, {
+      create: function(fn, idx) {
+        expect(fns).toInclude(fn);
+        arr[idx] = fn;
+        return arr;
+      },
+      before: function(storage) {
+        expect(storage).toEqual(arr);
+      },
+      after: function(result, storage) {
+        expect(storage).toEqual(arr);
+      },
+    })(function(error) {
+      expect(error).toEqual(null);
+      expect(arr).toEqual(fns);
+    });
+    done();
+  });
+});

--- a/src/bach/test/verifyArguments.mjs
+++ b/src/bach/test/verifyArguments.mjs
@@ -1,0 +1,32 @@
+const {default: expect} = await import('expect');
+
+const {verifyArguments} = await import('../lib/helpers.js');
+
+function validArg() {}
+
+describe('verifyArguments', function() {
+
+  it('should act as pass-through for a valid set of arguments', function(done) {
+    const args = [validArg, validArg];
+    expect(verifyArguments(args)).toEqual(args);
+    done();
+  });
+
+  it('should throw descriptive error message on invalid argument', function(done) {
+    function invalid() {
+      verifyArguments([validArg, 'invalid', validArg]);
+    }
+
+    expect(invalid).toThrow('Only functions can be combined, got string for argument 1');
+    done();
+  });
+
+  it('should throw descriptive error message on when no arguments provided', function(done) {
+    function empty() {
+      verifyArguments([]);
+    }
+
+    expect(empty).toThrow('A set of functions to combine is required');
+    done();
+  });
+});

--- a/src/undertaker/index.js
+++ b/src/undertaker/index.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events').EventEmitter;
-const bach = require('bach');
+const bach = require('../bach/index.js');
 const DefaultRegistry = require('undertaker-registry');
 
 const metadata = require('./metadata');


### PR DESCRIPTION
[x] bach inlined
[x] code rewrote to ES6+
[x] tests ported to ESM
[x] useless deps deleted

I checked the exports of bach. We don't need to export it because it is internal lib, and we didn't allow to replace bach or its parts to the customer's code.

closes #20